### PR TITLE
Fix hosts file key path

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -1,2 +1,2 @@
 [linux_servers]
-node1 ansible_host=172.18.15.115 ansible_user=node1 ansbile_ssh_private_key=/home/admin/.ssh/node1_id_rsa.pub
+node1 ansible_host=172.18.15.115 ansible_user=node1 ansible_ssh_private_key=/home/admin/.ssh/node1_id_rsa


### PR DESCRIPTION
## Summary
- fix misspelled `ansible_ssh_private_key` setting
- ensure the path points to the private key without `.pub`

## Testing
- `ansible-playbook --syntax-check postgre_playbook.yml` *(fails: command not found)*
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850058cde448329b420aca2eec6d2ee